### PR TITLE
add docker development container with simplified getting started

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.5.2
+MAINTAINER Emanuele Palazzetti <hello@palazzetti.me>
+
+# environment variables
+ENV DJANGO_SETTINGS_MODULE website.settings.dev
+ENV DATABASE_URL postgres://devel:123456@postgres:5432/evonoveit
+ENV CACHE_URL redis://redis:6379/0
+
+ENV UWSGI_HTTP 0.0.0.0:8000
+ENV UWSGI_PROCESSES 2
+
+WORKDIR /app
+
+COPY . /app/
+RUN pip install -r requirements.txt
+
+EXPOSE 8000
+
+CMD ["uwsgi", "--need-app", "--chdir", "django-website", "--py-autoreload", "1", "--http", "8000", "--module", "website.wsgi"]

--- a/README.rst
+++ b/README.rst
@@ -19,9 +19,9 @@ Starting this website requires the following backend services up and running:
 * Redis
 * PostgreSQL
 
-If you want to launch your backend services via ``docker-compose``, just::
+A docker development container is available and you can start all the stack, just::
 
-    $ docker-compose up
+    $ docker-compose up -d
 
 Populate the database
 ~~~~~~~~~~~~~~~~~~~~~
@@ -31,13 +31,12 @@ using the admin (or in general be a data insert operator), you can launch the fo
 the database schema, the initial superuser, the blog page linked to the home page and a set of initial data
 for a fake company.
 
-From the ``django-website`` folder, launch::
+From the root folder, launch::
 
-    $ python manage.py migrate
-    $ python manage.py createsuperuser
-    $ python manage.py create_pages
-    $ python manage.py load_test_data
-    $ python manage.py runserver
+    $ docker-compose run django python django-website/manage.py migrate
+    $ docker-compose run django python django-website/manage.py createsuperuser
+    $ docker-compose run django python django-website/manage.py create_pages
+    $ docker-compose run django python django-website/manage.py load_test_data
 
 Settings
 --------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,20 @@
 # This file must be used only for development purposes
+version: "2"
 
-db:
-    image: postgres:9.5.2
-    ports:
-        - "5432:5432"
-    environment:
-        - POSTGRES_USER=devel
-        - POSTGRES_PASSWORD=123456
-        - POSTGRES_DB=evonoveit
+services:
+    postgres:
+        image: postgres:9.5.2
+        environment:
+            - POSTGRES_USER=devel
+            - POSTGRES_PASSWORD=123456
+            - POSTGRES_DB=evonoveit
 
-redis:
-    image: redis:3.0.7
-    ports:
-        - "6379:6379"
+    redis:
+        image: redis:3.0.7
+
+    django:
+        build: .
+        volumes:
+          - .:/app
+        ports:
+          - "8000:8000"

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.1
+python-3.5.2


### PR DESCRIPTION
# What it does?

Create a Docker container so that developers (especially frontend developers) can start the whole project without knowing anything (neither the existence of Python :)).
# What contains?
- a `Dockerfile`
- an updated `docker-compose.yml`
- it runs the whole container using `uwsgi` instead of the Django run server
- instructions on README
- update the deployment `runtime.txt` so that it matches the development container
