### PR TITLE
update Wheelie dependency and tools

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,20 @@ From the ``django-website`` folder, launch::
     $ python manage.py load_test_data
     $ python manage.py runserver
 
+Frontend development
+~~~~~~~~~~~~~~~~~~~~
+
+The frontend application, uses Wheelie toolchain. To start the livereload, enter in the
+``django-website/wheelie/`` folder and just::
+
+    $ npm run wheelie
+
+When the frontend is ready to be deployed, launch the production build and commit all files in the
+repository::
+
+    $ npm run build
+    $ git commit -m'process static files'
+
 Settings
 --------
 

--- a/django-website/wheelie/gulpfile.js
+++ b/django-website/wheelie/gulpfile.js
@@ -1,12 +1,15 @@
 require('gulp');
 
 // importing Wheelie instance and a list of tasks (recipe)
-var wheelie = require('wheelie');
+var Wheelie = require('wheelie');
 var recipe = require('wheelie-recipe');
 
 // adding a recipe to Wheelie, defining the default task
+var wheelie = new Wheelie();
 wheelie.add(recipe);
-wheelie.setDefault('watch');
+
+// disable browser-sync
+wheelie.disable('browser-sync');
 
 // build customizations
 var vendors = [
@@ -34,6 +37,4 @@ wheelie.update('uglify', {
   vendors: vendors
 });
 
-wheelie.setBuild('static/');
-wheelie.setDist('static/');
 wheelie.build();

--- a/django-website/wheelie/package.json
+++ b/django-website/wheelie/package.json
@@ -4,7 +4,9 @@
   "description": "Evonove website",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "wheelie": "nodemon --watch gulpfile.js --exec gulp",
+    "build": "gulp build --production"
   },
   "repository": {
     "type": "https",
@@ -17,8 +19,9 @@
   },
   "homepage": "https://github.com/evonove/evonove.it",
   "devDependencies": {
-    "gulp": "3.9.0",
-    "wheelie": "0.1.3",
-    "wheelie-recipe": "0.2.1"
+    "gulp": "3.9.1",
+    "nodemon": "1.10.0",
+    "wheelie": "0.3.0",
+    "wheelie-recipe": "0.3.1"
   }
 }


### PR DESCRIPTION
# What it does?

Update Wheelie dependency, providing more tools to simplify the development.
# What it contains?
- Wheelie 0.3.0
- two utility commands to start Wheelie in livereload and to build the production version
