### PR TITLE
Added support for multiple allowed hosts to the env var

### DIFF
--- a/django-website/website/settings/base.py
+++ b/django-website/website/settings/base.py
@@ -26,9 +26,8 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-ALLOWED_HOSTS = [
-    env("DJANGO_ALLOWED_HOSTS"),
-]
+DEFAULT_ALLOWED_HOSTS = 'localhost, 127.0.0.1, [::1]'
+ALLOWED_HOSTS = env('DJANGO_ALLOWED_HOSTS', DEFAULT_ALLOWED_HOSTS).replace(' ', '').split(',')
 
 DEBUG = env('DJANGO_DEBUG', False)
 


### PR DESCRIPTION
we need it to add both `www.evonove.it` and `evonove.it` to allowed hosts