### PR TITLE
Remove a wrong white line on the bottom of team pictures

### DIFF
--- a/django-website/frontend/client/scss/layout/_team.scss
+++ b/django-website/frontend/client/scss/layout/_team.scss
@@ -68,7 +68,6 @@
 
   // Add a background to the picture keeping the teammate's drop shadow visible.
   &::before {
-    background-color: $white;
     bottom: 0;
     content: '';
     left: 0;


### PR DESCRIPTION
**What it does**

Remove a wrong white line on the bottom of team pictures