### PR TITLE
Blog post title is now a link to the post

### DIFF
--- a/django-website/blog/templates/blog/blog_page.html
+++ b/django-website/blog/templates/blog/blog_page.html
@@ -26,7 +26,9 @@
           </a>
         </div>
         <div class="post_preview-info -u-element_to_reveal -u-reveal_from_right">
-          <h2>{{ article.title }}</h2>
+          <a href="{% pageurl article %}">
+            <h2>{{ article.title }}</h2>
+          </a>
           <div class="post_preview-info-metadata u-capitalize">
             <span class="post_preview-info-metadata-author">{{ article.owner.get_full_name|default:article.owner }}</span>
             <span class="post_preview-info-metadata-separator">·</span>


### PR DESCRIPTION
**What it does**

Blog post title is now a link to the post