### PR TITLE
Replace social links text with icons in the footer

### DIFF
--- a/django-website/frontend/client/scss/layout/_footer.scss
+++ b/django-website/frontend/client/scss/layout/_footer.scss
@@ -58,15 +58,13 @@
   }
 }
 
-.footer-email-text,
-.footer-social-text {
+.footer-email-text {
   @media #{$max-medium} {
     display: none;
   }
 }
 
-.footer-email-icon,
-.footer-social-icon {
+.footer-email-icon {
   display: none;
 
   @media #{$max-medium} {
@@ -78,6 +76,12 @@
 .footer-social-icon > svg {
   fill: $light-grey;
   height: 1rem;
+  transition: all .262s;
+
+  &:hover {
+    fill: $white;
+    filter: drop-shadow(0 0 10px rgba(59,179,181,.95));
+  }
 }
 
 .body_blog .footer-email-icon > svg,

--- a/django-website/templates/partials/footer.html
+++ b/django-website/templates/partials/footer.html
@@ -8,20 +8,17 @@
   <p class="footer-copyright">&copy; {% now "Y" %} by Evonove. All rights are reserved.</p>
   <ul class="footer-social">
     <li>
-      <a class="button glow_link footer-social-text is-line_appearing" href="{{ options.facebook }}" target="_blank">Facebook</a>
-      <a class="footer-social-icon" href="{{ options.facebook }}" target="_blank">
+      <a class="glow_link footer-social-icon" href="{{ options.facebook }}" target="_blank">
         {% include "./svg/social_icons/facebook.html" %}
       </a>
     </li>
     <li>
-      <a class="button glow_link footer-social-text is-line_appearing" href="{{ options.twitter }}" target="_blank">Twitter</a>
-      <a class="footer-social-icon" href="{{ options.twitter }}" target="_blank">
+      <a class="glow_link footer-social-icon" href="{{ options.twitter }}" target="_blank">
         {% include "./svg/social_icons/twitter.html" %}
       </a>
     </li>
     <li>
-      <a class="button glow_link footer-social-text is-line_appearing" href="{{ options.github }}" target="_blank">GitHub</a>
-      <a class="footer-social-icon" href="{{ options.github }}" target="_blank">
+      <a class="glow_link footer-social-icon" href="{{ options.github }}" target="_blank">
         {% include "./svg/social_icons/github.html" %}
       </a>
     </li>


### PR DESCRIPTION
**What it does**

Footer social links are now icons instead of text.