### PR TITLE
Fix an issue on Firefox Quantum where services titles had a wrong transition

### DIFF
--- a/django-website/agency/templates/agency/agency_page.html
+++ b/django-website/agency/templates/agency/agency_page.html
@@ -26,8 +26,8 @@
   <ul class="services-list">
     {% for service in page.services.all %}
       <li class="services-list-item js-reveal_service">
-        <div class="services-list-item-title">
-          <h3 class="-u-element_to_reveal -u-reveal_from_bottom">{{ service.title }}</h3>
+        <div class="services-list-item-title -u-element_to_reveal -u-reveal_from_bottom">
+          <h3>{{ service.title }}</h3>
         </div>
         <div class="services-list-item-divider"></div>
         <div class="services-list-item-description -u-element_to_reveal -u-reveal_from_bottom">{{ service.description|richtext }}</div>

--- a/django-website/frontend/client/scss/layout/_services.scss
+++ b/django-website/frontend/client/scss/layout/_services.scss
@@ -103,7 +103,6 @@
 .services-list-item-title > h3 {
   font-size: 1.618rem;
   font-weight: $weight-normal;
-  opacity: 0;
   text-align: center;
   -webkit-text-fill-color: transparent; // [1]
   text-transform: none;
@@ -111,7 +110,7 @@
 }
 
 // Reveal each service title
-.services-list-item.is-element_revealed .services-list-item-title > h3 {
+.services-list-item.is-element_revealed .services-list-item-title {
   opacity: 1;
   transform: translate3d(0, 0, 0);
 }

--- a/django-website/home/templates/home/home_page.html
+++ b/django-website/home/templates/home/home_page.html
@@ -28,8 +28,8 @@
   <ul class="services-list">
     {% for service in services %}
       <li class="services-list-item js-reveal_service">
-        <div class="services-list-item-title">
-          <h3 class="-u-element_to_reveal -u-reveal_from_bottom">{{ service.title }}</h3>
+        <div class="services-list-item-title -u-element_to_reveal -u-reveal_from_bottom">
+          <h3>{{ service.title }}</h3>
         </div>
         <div class="services-list-item-divider"></div>
       </li>


### PR DESCRIPTION
**What it does**

Fix an issue on Firefox Quantum where services titles appear without a proper transition.