### PR TITLE
Add trivy to local testing workflow and make task to run trivy scan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,5 @@ vendors/
 export*
 
 test-results
+
+trivy-results

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,12 @@ filename_compressed = $(filename).gz
 bucket_uri ?= gs://$(bucket_name)/evonove.it/$(filename_compressed)
 services_file = docker-services.yml
 
+
+now_time := $(shell date -d "tomorrow" '+%Y-%m-%d-%H:%M:%S')
+json_report = --format json --output /evonove/trivy-results/trivy-$(now_time).json
+html_report = --format template --template "@/evonove/trivy-template/html.tpl" --output /evonove/trivy-results/trivy-$(now_time).html
+
+
 .PHONY: export-sql import-production-db start-services stop-services drop-services
 # This needs to be secondary so we don't export the db if we already have it
 .SECONDARY: $(filename_compressed)
@@ -38,3 +44,21 @@ stop-services:
 
 drop-services:
 	docker compose -f $(services_file) down
+
+trivy:
+	mkdir -p ./trivy-results
+	@echo "Select output format:"; \
+	echo "1) JSON"; \
+	echo "2) HTML"; \
+	read -p "Enter choice [1-2]: " choice; \
+	case $$choice in \
+			1) format_flag="$(json_report)";; \
+			2) format_flag="$(html_report)";; \
+			*) echo "Invalid choice"; exit 1;; \
+		esac; \
+	docker run --rm -v $$(pwd):/evonove aquasec/trivy fs \
+	--severity HIGH,CRITICAL \
+	--dependency-tree \
+    --scanners vuln,misconfig,secret /evonove \
+    --skip-dirs /evonove/.tox,/evonove/.venv --ignore-unfixed \
+    $$format_flag

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ This type of scan generatate JSON or HTML report and save the resulting report i
     
     trivy-results/trivy-{time_of_creation}.html or trivy-results/trivy-{time_of_creation}.json
 
-The trivy scan is also integrated into tox with a only-text output in console, just run the command:
+The trivy scan is also integrated into tox with a text-only output in console, just run the command:
 
     $ tox
 

--- a/README.md
+++ b/README.md
@@ -89,3 +89,21 @@ Deployed in GC kubernetes cluster, check configuration files in:
 
 [1]: https://evonove.it/ "Evonove"
 [2]: https://wagtail.io/ "Wagtail"
+
+## Vulnerability Scan
+
+To perform a single scan use :
+
+    $ make trivy
+    
+This type of scan generatate JSON or HTML report and save the resulting report into     
+    
+    trivy-results/trivy-{time_of_creation}.html or trivy-results/trivy-{time_of_creation}.json
+
+The trivy scan is also integrated into tox with a only-text output in console, just run the command:
+
+    $ tox
+
+Or launching only trivy scan with:
+
+    $ tox -e trivy

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ addopts =
 [tox]
 requires =
     tox>=4
-envlist = ruff, ruff-format, py313
+envlist = ruff, ruff-format, py313, trivy
 
 [testenv:py313]
 runner = uv-venv-lock-runner
@@ -34,3 +34,14 @@ skip_install = true
 deps =
     ruff
 commands = ruff format --exclude migrations,node_modules --check django-website
+
+[testenv:trivy]
+description = Run trivy scan in local project
+skip_install = true
+allowlist_externals = sh
+commands =
+    sh -c 'docker run --rm -v $(pwd):/evonove aquasec/trivy fs \
+	    --severity HIGH,CRITICAL \
+        --scanners vuln,misconfig,secret /evonove \
+        --skip-dirs /evonove/.tox,/evonove/.venv --ignore-unfixed \
+        --format table'

--- a/tox.ini
+++ b/tox.ini
@@ -38,10 +38,10 @@ commands = ruff format --exclude migrations,node_modules --check django-website
 [testenv:trivy]
 description = Run trivy scan in local project
 skip_install = true
-allowlist_externals = sh
+allowlist_externals = docker
 commands =
-    sh -c 'docker run --rm -v $(pwd):/evonove aquasec/trivy fs \
+    docker run --rm -v {toxinidir}:/evonove aquasec/trivy fs \
 	    --severity HIGH,CRITICAL \
         --scanners vuln,misconfig,secret /evonove \
         --skip-dirs /evonove/.tox,/evonove/.venv --ignore-unfixed \
-        --format table'
+        --format table

--- a/trivy-template/html.tpl
+++ b/trivy-template/html.tpl
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+{{- if . }}
+    <style>
+      * {
+        font-family: Arial, Helvetica, sans-serif;
+      }
+      h1 {
+        text-align: center;
+      }
+      .group-header th {
+        font-size: 200%;
+      }
+      .sub-header th {
+        font-size: 150%;
+      }
+      table, th, td {
+        border: 1px solid black;
+        border-collapse: collapse;
+        white-space: nowrap;
+        padding: .3em;
+      }
+      table {
+        margin: 0 auto;
+      }
+      .severity {
+        text-align: center;
+        font-weight: bold;
+        color: #fafafa;
+      }
+      .severity-LOW .severity { background-color: #5fbb31; }
+      .severity-MEDIUM .severity { background-color: #e9c600; }
+      .severity-HIGH .severity { background-color: #ff8800; }
+      .severity-CRITICAL .severity { background-color: #e40000; }
+      .severity-UNKNOWN .severity { background-color: #747474; }
+      .severity-LOW { background-color: #5fbb3160; }
+      .severity-MEDIUM { background-color: #e9c60060; }
+      .severity-HIGH { background-color: #ff880060; }
+      .severity-CRITICAL { background-color: #e4000060; }
+      .severity-UNKNOWN { background-color: #74747460; }
+      table tr td:first-of-type {
+        font-weight: bold;
+      }
+      .links a,
+      .links[data-more-links=on] a {
+        display: block;
+      }
+      .links[data-more-links=off] a:nth-of-type(1n+5) {
+        display: none;
+      }
+      a.toggle-more-links { cursor: pointer; }
+    </style>
+    <title>{{- escapeXML ( index . 0 ).Target }} - Trivy Report - {{ now }} </title>
+    <script>
+      window.onload = function() {
+        document.querySelectorAll('td.links').forEach(function(linkCell) {
+          var links = [].concat.apply([], linkCell.querySelectorAll('a'));
+          [].sort.apply(links, function(a, b) {
+            return a.href > b.href ? 1 : -1;
+          });
+          links.forEach(function(link, idx) {
+            if (links.length > 3 && 3 === idx) {
+              var toggleLink = document.createElement('a');
+              toggleLink.innerText = "Toggle more links";
+              toggleLink.href = "#toggleMore";
+              toggleLink.setAttribute("class", "toggle-more-links");
+              linkCell.appendChild(toggleLink);
+            }
+            linkCell.appendChild(link);
+          });
+        });
+        document.querySelectorAll('a.toggle-more-links').forEach(function(toggleLink) {
+          toggleLink.onclick = function() {
+            var expanded = toggleLink.parentElement.getAttribute("data-more-links");
+            toggleLink.parentElement.setAttribute("data-more-links", "on" === expanded ? "off" : "on");
+            return false;
+          };
+        });
+      };
+    </script>
+  </head>
+  <body>
+    <h1>{{- escapeXML ( index . 0 ).Target }} - Trivy Report - {{ now }}</h1>
+    <table>
+    {{- range . }}
+      <tr class="group-header"><th colspan="6">{{ .Type | toString | escapeXML }}</th></tr>
+      {{- if (eq (len .Vulnerabilities) 0) }}
+      <tr><th colspan="6">No Vulnerabilities found</th></tr>
+      {{- else }}
+      <tr class="sub-header">
+        <th>Package</th>
+        <th>Vulnerability ID</th>
+        <th>Severity</th>
+        <th>Installed Version</th>
+        <th>Fixed Version</th>
+        <th>Links</th>
+      </tr>
+        {{- range .Vulnerabilities }}
+      <tr class="severity-{{ escapeXML .Vulnerability.Severity }}">
+        <td class="pkg-name">{{ escapeXML .PkgName }}</td>
+        <td>{{ escapeXML .VulnerabilityID }}</td>
+        <td class="severity">{{ escapeXML .Vulnerability.Severity }}</td>
+        <td class="pkg-version">{{ escapeXML .InstalledVersion }}</td>
+        <td>{{ escapeXML .FixedVersion }}</td>
+        <td class="links" data-more-links="off">
+          {{- range .Vulnerability.References }}
+          <a href={{ escapeXML . | printf "%q" }}>{{ escapeXML . }}</a>
+          {{- end }}
+        </td>
+      </tr>
+        {{- end }}
+      {{- end }}
+      {{- if (eq (len .Misconfigurations ) 0) }}
+      <tr><th colspan="6">No Misconfigurations found</th></tr>
+      {{- else }}
+      <tr class="sub-header">
+        <th>Type</th>
+        <th>Misconf ID</th>
+        <th>Check</th>
+        <th>Severity</th>
+        <th>Message</th>
+      </tr>
+        {{- range .Misconfigurations }}
+      <tr class="severity-{{ escapeXML .Severity }}">
+        <td class="misconf-type">{{ escapeXML .Type }}</td>
+        <td>{{ escapeXML .ID }}</td>
+        <td class="misconf-check">{{ escapeXML .Title }}</td>
+        <td class="severity">{{ escapeXML .Severity }}</td>
+        <td class="link" data-more-links="off"  style="white-space:normal;">
+          {{ escapeXML .Message }}
+          <br>
+            <a href={{ escapeXML .PrimaryURL | printf "%q" }}>{{ escapeXML .PrimaryURL }}</a>
+          </br>
+        </td>
+      </tr>
+        {{- end }}
+      {{- end }}
+    {{- end }}
+    </table>
+{{- else }}
+  </head>
+  <body>
+    <h1>Trivy Returned Empty Report</h1>
+{{- end }}
+  </body>
+</html>


### PR DESCRIPTION
To avoid the need for Trivy to be installed on the developer's computer, it was decided to run the Trivy scan using the Docker container provided by Aqua Security.

- Added a makefile task to run Trivy scan
- Integrate trivy scan as tox env

This PR close #230 