### PR TITLE
Update CircleCI image tagging strategy to enhance GCP artifacts registry cleanup policies rules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ commands:
   set-image-tag-env-var:
     steps:
       - run:
-          name: Set IMAGE_TAG and IMAGE_TAG_SHA environment variables
+          name: Set IMAGE_TAG environment variable
           command: bash .circleci/scripts/set-image-tag.sh
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,13 @@ executors:
     docker:
       - image: cimg/python:3.13.3
 
+commands:
+  set-image-tag-env-var:
+    steps:
+      - run:
+          name: Set IMAGE_TAG and IMAGE_TAG_SHA environment variables
+          command: bash .circleci/scripts/set-image-tag.sh
+
 workflows:
   test_build_push:
     jobs:
@@ -45,14 +52,7 @@ workflows:
             - google-cloud-platform
           requires:
             - test
-      - tag:
-          context:
-            - google-cloud-platform
-          requires:
-            - build-and-push
           filters:
-            branches:
-              ignore: /.*/
             tags:
               only: /.*/
       - trivy-scan:
@@ -60,6 +60,9 @@ workflows:
             - google-cloud-platform
           requires:
             - build-and-push
+          filters:
+            tags:
+              only: /.*/
 
 jobs:
   test:
@@ -129,7 +132,7 @@ jobs:
       - store_artifacts:
           path: scan-results/scan_results.json
           destination: scan-results
-          
+
   pa11y-ci:
     docker:
       - image: cimg/python:3.13.3-browsers
@@ -172,27 +175,26 @@ jobs:
       - gcp-gcr/gcr-auth:
           gcloud-service-key: CLEARTEXT_GCLOUD_SERVICE_KEY
           registry-url: europe-west3-docker.pkg.dev
+      - set-image-tag-env-var
       - gcp-gcr/build-image:
           image: << pipeline.parameters.repository-name >>/<< pipeline.parameters.image-name >>
-          tag: $CIRCLE_SHA1
+          tag: $IMAGE_TAG
           dockerfile: containers/Dockerfile
           registry-url: europe-west3-docker.pkg.dev
       - gcp-gcr/push-image:
           image: << pipeline.parameters.repository-name >>/<< pipeline.parameters.image-name >>
-          tag: $CIRCLE_SHA1
+          tag: $IMAGE_TAG
           registry-url: europe-west3-docker.pkg.dev
-
-  tag:
-    executor: builder
-    steps:
-      - gcp-gcr/gcr-auth:
-          gcloud-service-key: CLEARTEXT_GCLOUD_SERVICE_KEY
-          registry-url: europe-west3-docker.pkg.dev
-      - gcp-gcr/tag-image:
-          image: << pipeline.parameters.repository-name >>/<< pipeline.parameters.image-name >>
-          registry-url: europe-west3-docker.pkg.dev
-          source-tag: $CIRCLE_SHA1
-          target-tag: $CIRCLE_TAG
+      - when:
+          # We have an IMAGE_TAG_SHA value, so, let's attach the SHA
+          # for default branch and git tags image traceability
+          condition: $IMAGE_TAG_SHA
+          steps:
+            - gcp-gcr/tag-image:
+                image: << pipeline.parameters.repository-name >>/<< pipeline.parameters.image-name >>
+                registry-url: europe-west3-docker.pkg.dev
+                source-tag: $IMAGE_TAG
+                target-tag: $IMAGE_TAG_SHA
 
   trivy-scan:
     docker:
@@ -201,6 +203,7 @@ jobs:
       - gcp-gcr/gcr-auth:
           gcloud-service-key: CLEARTEXT_GCLOUD_SERVICE_KEY
           registry-url: europe-west3-docker.pkg.dev
+      - set-image-tag-env-var
       - run:
           name: Install Trivy and run image scan
           command: |
@@ -214,7 +217,7 @@ jobs:
             ./trivy image --format json --output trivy-result.json \
             --severity HIGH,CRITICAL --scanners vuln,misconfig,secret --ignore-unfixed \
             --exit-code 1 \
-            europe-west3-docker.pkg.dev/$GOOGLE_PROJECT_ID/<< pipeline.parameters.repository-name >>/<< pipeline.parameters.image-name >>:$CIRCLE_SHA1 \
+            europe-west3-docker.pkg.dev/$GOOGLE_PROJECT_ID/<< pipeline.parameters.repository-name >>/<< pipeline.parameters.image-name >>:$IMAGE_TAG
       - store_artifacts:
           path: trivy-result.json
           destination: trivy-results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,16 +185,6 @@ jobs:
           image: << pipeline.parameters.repository-name >>/<< pipeline.parameters.image-name >>
           tag: $IMAGE_TAG
           registry-url: europe-west3-docker.pkg.dev
-      - when:
-          # We have an IMAGE_TAG_SHA value, so, let's attach the SHA
-          # for default branch and git tags image traceability
-          condition: $IMAGE_TAG_SHA
-          steps:
-            - gcp-gcr/tag-image:
-                image: << pipeline.parameters.repository-name >>/<< pipeline.parameters.image-name >>
-                registry-url: europe-west3-docker.pkg.dev
-                source-tag: $IMAGE_TAG
-                target-tag: $IMAGE_TAG_SHA
 
   trivy-scan:
     docker:

--- a/.circleci/scripts/set-image-tag.sh
+++ b/.circleci/scripts/set-image-tag.sh
@@ -1,28 +1,23 @@
 #!/bin/bash
 #
-# Set IMAGE_TAG and IMAGE_TAG_SHA environment variables for Docker image tagging.
+# Set IMAGE_TAG environment variables for Docker image tagging.
 #
 # This script determines the appropriate Docker image tag based on the CI context:
-# - Git tags: Uses the tag name (e.g., v1.2.3)
-# - Main branch: Uses 'latest'
-# - PR: Uses 'pr-<number>'
+# - Git tags: uses the git tag name (e.g., 1.2.3)
+# - Main branch: uses 'latest'
+# - PR: uses 'pr-<number>'
 
 set -euo pipefail
 
 if [ -n "${CIRCLE_TAG:-}" ]; then
-  # Git tag push: use tag name as primary, SHA as secondary
+  # Git tag push: use tag name as primary
   echo "export IMAGE_TAG=$CIRCLE_TAG" >> "$BASH_ENV"
-  echo "export IMAGE_TAG_SHA=$CIRCLE_SHA1" >> "$BASH_ENV"
 elif [ "$CIRCLE_BRANCH" = "main" ]; then
-  # Main branch: use 'latest' as primary, SHA as secondary
+  # Main branch: use 'latest' as primary
   echo "export IMAGE_TAG=latest" >> "$BASH_ENV"
 else
   # PR: use 'pr-<number>' attaching the tag to 
   # the latest pr branch commit
   PR_NUMBER=${CIRCLE_PULL_REQUEST##*/}
-  if [ -z "$PR_NUMBER" ]; then
-    echo "Error: No PR number found. Ensure a PR is open."
-    exit 1
-  fi
   echo "export IMAGE_TAG=pr-${PR_NUMBER}" >> "$BASH_ENV"
 fi

--- a/.circleci/scripts/set-image-tag.sh
+++ b/.circleci/scripts/set-image-tag.sh
@@ -16,7 +16,6 @@ if [ -n "${CIRCLE_TAG:-}" ]; then
 elif [ "$CIRCLE_BRANCH" = "main" ]; then
   # Main branch: use 'latest' as primary, SHA as secondary
   echo "export IMAGE_TAG=latest" >> "$BASH_ENV"
-  echo "export IMAGE_TAG_SHA=$CIRCLE_SHA1" >> "$BASH_ENV"
 else
   # PR: use 'pr-<number>' attaching the tag to 
   # the latest pr branch commit
@@ -26,5 +25,4 @@ else
     exit 1
   fi
   echo "export IMAGE_TAG=pr-${PR_NUMBER}" >> "$BASH_ENV"
-  echo "export IMAGE_TAG_SHA=" >> "$BASH_ENV"
 fi

--- a/.circleci/scripts/set-image-tag.sh
+++ b/.circleci/scripts/set-image-tag.sh
@@ -10,11 +10,11 @@
 set -euo pipefail
 
 if [ -n "${CIRCLE_TAG:-}" ]; then
-  # Git tag push: use tag name as primary
-  echo "export IMAGE_TAG=$CIRCLE_TAG" >> "$BASH_ENV"
+  # Git tag push: use git tag and sha
+  echo "export IMAGE_TAG=$CIRLCE_SHA1,$CIRCLE_TAG" >> "$BASH_ENV"
 elif [ "$CIRCLE_BRANCH" = "main" ]; then
-  # Main branch: use 'latest' as primary
-  echo "export IMAGE_TAG=latest" >> "$BASH_ENV"
+  # Main branch: use 'latest' and sha
+  echo "export IMAGE_TAG=$CIRCLE_SHA1,latest" >> "$BASH_ENV"
 else
   # PR: use 'pr-<number>' attaching the tag to 
   # the latest pr branch commit

--- a/.circleci/scripts/set-image-tag.sh
+++ b/.circleci/scripts/set-image-tag.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Set IMAGE_TAG and IMAGE_TAG_SHA environment variables for Docker image tagging.
+#
+# This script determines the appropriate Docker image tag based on the CI context:
+# - Git tags: Uses the tag name (e.g., v1.2.3)
+# - Main branch: Uses 'latest'
+# - PR: Uses 'pr-<number>'
+
+set -euo pipefail
+
+if [ -n "${CIRCLE_TAG:-}" ]; then
+  # Git tag push: use tag name as primary, SHA as secondary
+  echo "export IMAGE_TAG=$CIRCLE_TAG" >> "$BASH_ENV"
+  echo "export IMAGE_TAG_SHA=$CIRCLE_SHA1" >> "$BASH_ENV"
+elif [ "$CIRCLE_BRANCH" = "main" ]; then
+  # Main branch: use 'latest' as primary, SHA as secondary
+  echo "export IMAGE_TAG=latest" >> "$BASH_ENV"
+  echo "export IMAGE_TAG_SHA=$CIRCLE_SHA1" >> "$BASH_ENV"
+else
+  # PR: use 'pr-<number>' attaching the tag to 
+  # the latest pr branch commit
+  PR_NUMBER=${CIRCLE_PULL_REQUEST##*/}
+  if [ -z "$PR_NUMBER" ]; then
+    echo "Error: No PR number found. Ensure a PR is open."
+    exit 1
+  fi
+  echo "export IMAGE_TAG=pr-${PR_NUMBER}" >> "$BASH_ENV"
+  echo "export IMAGE_TAG_SHA=" >> "$BASH_ENV"
+fi

--- a/containers/start.sh
+++ b/containers/start.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-# 
 if [ "$1" = 'uwsgi' ]; then
     python django-website/manage.py collectstatic --noinput
     python django-website/manage.py migrate

--- a/containers/start.sh
+++ b/containers/start.sh
@@ -2,6 +2,7 @@
 
 set -e
 
+# 
 if [ "$1" = 'uwsgi' ]; then
     python django-website/manage.py collectstatic --noinput
     python django-website/manage.py migrate


### PR DESCRIPTION
We started recently to consider the idea to push built images at every CI run to GCP artifacts registry, but this will bloat in no time the registries. The idea here is to tag images for PR open, default branch (what CircleCI calls default branch) and git tags. 

 - Git tags: Uses the tag name (e.g., v1.2.3), persistent 
 - Main branch: Uses 'latest', overrides at every main build
 - PR: Uses 'pr-<number>', overrides at every pr branch push
 
 This tags should allow use to define and enable sane GCP cleanup policy for our registries.
 
 #246 for discussion
